### PR TITLE
Added install_virtualenv

### DIFF
--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -178,6 +178,7 @@ def submit_topology(name=None, env_name="prod", workers=2, ackers=2,
 
     # Check if we need to maintain virtualenv during the process
     use_venv = env_config.get('use_virtualenv', True)
+    install_venv = env_config.get('install_virtualenv', use_venv)
     # Setup the fabric env dictionary
     activate_env(env_name)
     # Run pre_submit actions provided by project
@@ -186,11 +187,13 @@ def submit_topology(name=None, env_name="prod", workers=2, ackers=2,
     # If using virtualenv, set it up, and make sure paths are correct in specs
     if use_venv:
         config["virtualenv_specs"] = config["virtualenv_specs"].rstrip("/")
-        create_or_update_virtualenvs(
-            env_name,
-            name,
-            "{}/{}.txt".format(config["virtualenv_specs"], name),
-            virtualenv_flags=env_config.get('virtualenv_flags'))
+        
+        if install_venv:
+          create_or_update_virtualenvs(
+              env_name,
+              name,
+              "{}/{}.txt".format(config["virtualenv_specs"], name),
+              virtualenv_flags=env_config.get('virtualenv_flags'))
         streamparse_run_path = '/'.join([env.virtualenv_root, name, 'bin',
                                          'streamparse_run'])
         # Update python paths in bolts


### PR DESCRIPTION
Added option to install virtual env independendly on use_virtualenv.

We have some servers that doesn't have internet access to pip install is not an option. We install virtualenv by ourselves as rpm packages, but we still want to use virtualenvs.

Otherwise it will not find streamparse_run. See:
https://github.com/Parsely/streamparse/issues/258
